### PR TITLE
Don't strip quotation marks at the end of normal chat messages after encoding.

### DIFF
--- a/kchat/lib/global.php
+++ b/kchat/lib/global.php
@@ -213,7 +213,7 @@ function reverse($a){
 }
 
 function msgencode($data,$txt){
-	return trim(json_encode($txt),'"');
+	return substr(json_encode($txt), 1, -1);
 }
 
 function msgdecode($data,$txt){


### PR DESCRIPTION
In the case that a message ends with a `"`, json_encode encodes it to a `\"`, and trim removes that quotation mark since after it there is only one quotation mark more.

Messages that end like that are then stored in the database and since the encoded message is invalid json, users see empty messages.

To fix this i propose changing the trim() call to calling substr and removing explicitly just the first and last character.